### PR TITLE
Warning fix: wrong module name case.

### DIFF
--- a/Source/AccelByteUe4Sdk/AccelByteUe4Sdk.Build.cs
+++ b/Source/AccelByteUe4Sdk/AccelByteUe4Sdk.Build.cs
@@ -32,7 +32,7 @@ public class AccelByteUe4Sdk : ModuleRules
             "Sockets",
             "Json",
             "JsonUtilities",
-            "Http",
+            "HTTP",
             "WebSockets",
             "Networking",
             "SSL",


### PR DESCRIPTION
When building a target, the next warning message will be produced :

WARNING: Module 'Http' (referenced via Target -> AccelByteUe4Sdk.Build.cs) has incorrect text case. Did you mean 'HTTP'?