### PR TITLE
Remove BOM from all files

### DIFF
--- a/Source/AccelByteUe4Sdk/Private/Api/AccelByteAMSApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Api/AccelByteAMSApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Api/AccelByteChallengeApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Api/AccelByteChallengeApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Api/AccelByteConfigurationsApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Api/AccelByteConfigurationsApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Api/AccelByteMatchmakingV2Api.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Api/AccelByteMatchmakingV2Api.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Api/AccelByteRewardApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Api/AccelByteRewardApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Api/AccelByteSeasonPassApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Api/AccelByteSeasonPassApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Api/AccelByteSessionApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Api/AccelByteSessionApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Blueprints/ABGroup.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Blueprints/ABGroup.cpp
@@ -1,4 +1,4 @@
-﻿#include "Blueprints/ABGroup.h"
+#include "Blueprints/ABGroup.h"
 
 using namespace AccelByte;
 

--- a/Source/AccelByteUe4Sdk/Private/Blueprints/ABUser.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Blueprints/ABUser.cpp
@@ -1,4 +1,4 @@
-﻿#include "Blueprints/ABUser.h"
+#include "Blueprints/ABUser.h"
 #include "JsonUtilities.h"
 
 using namespace AccelByte;

--- a/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteBPApiClient.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteBPApiClient.cpp
@@ -1,4 +1,4 @@
-﻿#include "Blueprints/AccelByteBPApiClient.h"
+#include "Blueprints/AccelByteBPApiClient.h"
 
 using namespace AccelByte;
 

--- a/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteBPLobby.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteBPLobby.cpp
@@ -1,4 +1,4 @@
-﻿#include "Blueprints/AccelByteBPLobby.h"
+#include "Blueprints/AccelByteBPLobby.h"
 
 using namespace AccelByte;
 

--- a/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteInstanceBlueprints.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Blueprints/AccelByteInstanceBlueprints.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte, Inc. All rights reserved.
+// Copyright (c) 2024 AccelByte, Inc. All rights reserved.
 // This is licensed software from Accelbyte Inc, for limitations
 // and restrictions contact your company contract manager
 

--- a/Source/AccelByteUe4Sdk/Private/Core/AccelByteEntitlementTokenGenerator.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/AccelByteEntitlementTokenGenerator.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/AccelByteInstance.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/AccelByteInstance.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/AccelByteJwtWrapper.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/AccelByteJwtWrapper.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/AccelByteJwtWrapper.h
+++ b/Source/AccelByteUe4Sdk/Private/Core/AccelByteJwtWrapper.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/AccelByteMessagingSystem.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/AccelByteMessagingSystem.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2025 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/AccelByteNotificationBuffer.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/AccelByteNotificationBuffer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/AccelByteWebSocket.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/AccelByteWebSocket.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/FUnrealWebSocketFactory.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/FUnrealWebSocketFactory.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/Version.cpp
+++ b/Source/AccelByteUe4Sdk/Private/Core/Version.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/Core/Version.h
+++ b/Source/AccelByteUe4Sdk/Private/Core/Version.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerInventoryApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerInventoryApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerMatchmakingV2Api.cpp
+++ b/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerMatchmakingV2Api.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerSessionApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerSessionApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerSessionBrowserApi.cpp
+++ b/Source/AccelByteUe4Sdk/Private/GameServerApi/AccelByteServerSessionBrowserApi.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteAMSApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteAMSApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteChallengeApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteChallengeApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteConfigurationsApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteConfigurationsApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteInventoryApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteInventoryApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteLoginQueueApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteLoginQueueApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteMatchmakingV2Api.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteMatchmakingV2Api.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteRewardApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteRewardApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteSeasonPassApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteSeasonPassApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteSessionApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteSessionApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteUGCApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteUGCApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Api/AccelByteUserApi.h
+++ b/Source/AccelByteUe4Sdk/Public/Api/AccelByteUserApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018-2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2018-2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Blueprints/ABGroup.h
+++ b/Source/AccelByteUe4Sdk/Public/Blueprints/ABGroup.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Blueprints/ABUser.h
+++ b/Source/AccelByteUe4Sdk/Public/Blueprints/ABUser.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "Core/AccelByteError.h"

--- a/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteBPApiClient.h
+++ b/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteBPApiClient.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "ABUser.h"

--- a/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteBPLobby.h
+++ b/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteBPLobby.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "Core/AccelByteApiClient.h"

--- a/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteInstanceBlueprints.h
+++ b/Source/AccelByteUe4Sdk/Public/Blueprints/AccelByteInstanceBlueprints.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte, Inc. All rights reserved.
+// Copyright (c) 2024 AccelByte, Inc. All rights reserved.
 // This is licensed software from Accelbyte Inc, for limitations
 // and restrictions contact your company contract manager
 

--- a/Source/AccelByteUe4Sdk/Public/Core/AccelByteDefines.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/AccelByteDefines.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/AccelByteEntitlementTokenGenerator.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/AccelByteEntitlementTokenGenerator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/AccelByteInstance.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/AccelByteInstance.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/AccelByteLockableQueue.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/AccelByteLockableQueue.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/AccelByteMessagingSystem.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/AccelByteMessagingSystem.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/AccelByteNotificationBuffer.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/AccelByteNotificationBuffer.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/AccelByteWebSocket.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/AccelByteWebSocket.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 - 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 - 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/FUnrealWebSocketFactory.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/FUnrealWebSocketFactory.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/IAccelByteTokenGenerator.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/IAccelByteTokenGenerator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/IWebSocketFactory.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/IWebSocketFactory.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/Platform/AccelBytePlatformHandleModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/Platform/AccelBytePlatformHandleModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Core/Platform/IAccelBytePlatformWrapper.h
+++ b/Source/AccelByteUe4Sdk/Public/Core/Platform/IAccelBytePlatformWrapper.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/GameServerApi/AccelByteServerMatchmakingV2Api.h
+++ b/Source/AccelByteUe4Sdk/Public/GameServerApi/AccelByteServerMatchmakingV2Api.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/GameServerApi/AccelByteServerSessionApi.h
+++ b/Source/AccelByteUe4Sdk/Public/GameServerApi/AccelByteServerSessionApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/GameServerApi/AccelByteServerSessionBrowserApi.h
+++ b/Source/AccelByteUe4Sdk/Public/GameServerApi/AccelByteServerSessionBrowserApi.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteAMSModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteAMSModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteChallengeModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteChallengeModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteConfigurationsModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteConfigurationsModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteInventoryModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteInventoryModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteMessagingSystemModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteMessagingSystemModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2023 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteSeasonPassModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteSeasonPassModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteSessionModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteSessionModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 -2024 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2022 -2024 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 

--- a/Source/AccelByteUe4Sdk/Public/Models/AccelByteUGCModels.h
+++ b/Source/AccelByteUe4Sdk/Public/Models/AccelByteUGCModels.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
+// Copyright (c) 2021 AccelByte Inc. All Rights Reserved.
 // This is licensed software from AccelByte Inc, for limitations
 // and restrictions contact your company contract manager.
 


### PR DESCRIPTION
When installing into a Perforce-backed project, BOM will cause p4 to use "utf8" filetype which can have undesirable effects.  Remove all usages of BOM to eliminate such potential complications.